### PR TITLE
Move file update call outside of forEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,11 @@ function replaceRootSyntaxWithAbsolutePath(bundle) {
           shouldUpdate = true
         }
       })
-
-      if (shouldUpdate) {
-        fs.writeFileSync(filePath, $.html())
-      }
     })
+    
+    if (shouldUpdate) {
+      fs.writeFileSync(filePath, $.html())
+    }
   }
 }
 


### PR DESCRIPTION
I figured that file is being written twice, if both `script` and `link` match the string. I think there was just a mistake and you meant to move the `writeFileSync` part outside of the loop (judging by the fact that `shouldUpdate` is also outside of the loop)